### PR TITLE
Psram buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/7571166c872e4dc8a899382389b73f8e)](https://app.codacy.com/gh/CelliesProjects/ESP32_VS1053_Stream?utm_source=github.com&utm_medium=referral&utm_content=CelliesProjects/ESP32_VS1053_Stream&utm_campaign=Badge_Grade_Settings)
 
 A streaming library for esp32 with a separate VS1053 mp3/ogg/aac/flac/wav decoder.
-This library plays mp3, ogg, aac, aac+ and flac files and streams. Supports http, https (insecure mode) and chunked audio streams.
+This library plays mp3, ogg, aac, aac+ and <strike>flac</strike> files and streams. Supports http, https (insecure mode) and chunked audio streams. 
+
+If there is psram found then a 32kB ringbuffer will be allocated and used, otherwise the stream will be played straight from the HTTPClient stream buffer. 
 
 This library needs [ESP_VS1053_Library](https://github.com/baldram/ESP_VS1053_Library) to communicate with the decoder.
 
@@ -76,17 +78,20 @@ void audio_eof_stream(const char* info) {
 }
 ```
 
-## Functions
+# Functions
 
 ### Initialize the VS1053 codec
 ```c++
 bool startDecoder(CS, DCS, DREQ)
 ```
+<hr>
 
 ### Check if VS1053 is responding
 ```c++
 bool isChipConnected()
 ```
+<hr>
+
 
 ### Start or resume a stream
 ```c++
@@ -101,32 +106,44 @@ bool connecttohost(url, user, pwd)
 ```c++
 bool connecttohost(url, user, pwd, offset)
 ```
+<hr>
+
 ### Stop a stream
 ```c++
 void stopSong()
 ```
+<hr>
+
 
 ### Feed the decoder
 ```c++
 void loop()
 ```
 This function has to called every couple of ms to feed the decoder with data. For bitrates up to 320kbps once every 25 ms is about right.
+<hr>
+
 
 ### Check if stream is running
 ```c++
 bool isRunning()
 ```
+<hr>
+
 
 ### Get the current volume
 ```c++
 uint8_t getVolume()
 ```
+<hr>
+
 
 ### Set the volume
 ```c++
 void setVolume(uint8_t volume)
 ```
 Value should be between 0-100.
+<hr>
+
 
 ### Set bass and treble
 ```c++
@@ -141,46 +158,56 @@ tonehf       = <0..15>        // Setting treble frequency lower limit x 1000 Hz
 tonela       = <0..15>        // Setting bass gain (0 = off, 1dB steps)
 tonelf       = <0..15>        // Setting bass frequency lower limit x 10 Hz
 ```
+<hr>
+
 
 ### Get the current used codec
 ```c++
 const char* currentCodec()
 ```
 Returns `STOPPED` if no stream is running.
+<hr>
 
 ### Get the current stream url
 ```c++
 const char* lastUrl()
 ```
 The current stream url might differ from the request url if the request url points to a playlist.
+<hr>
 
 ### Get the filesize
 ```c++
 size_t size()
 ```
 Returns `0` if the stream is a radio stream.
+<hr>
 
 ### Get the current position in the file
 ```c++
 size_t position()
 ```
 Returns `0` if the stream is a radio stream.
+<hr>
 
-## Event callbacks
+# Event callbacks
+### Station name callback.
 ```c++
 void audio_showstation(const char* info)
 ```
-Returns the station name.
+<hr>
 
+### Stream information callback.
 ```c++
 void audio_showstreamtitle(const char* info)
 ```
-Returns ICY stream information.
+<hr>
 
+### End of file callback.
 ```c++
 void audio_eof_stream(const char* info)
 ```
-Is called when the current stream reaches the end of file. Returns the current url.
+Returns the current url. Very handy for coding a playlist.
+<hr>
 
 ## License
 

--- a/src/ESP32_VS1053_Stream.cpp
+++ b/src/ESP32_VS1053_Stream.cpp
@@ -37,7 +37,7 @@ void ESP32_VS1053_Stream::_allocateRingbuffer()
         return;
     }
 
-    _ringbuffer_handle = xRingbufferCreateStatic(VS1053_PSRAM_BUFFER_SIZE, VS1053_BUFFER_TYPE, _buffer_storage, _buffer_struct);
+    _ringbuffer_handle = xRingbufferCreateStatic(VS1053_PSRAM_BUFFER_SIZE, RINGBUF_TYPE_BYTEBUF, _buffer_storage, _buffer_struct);
     if (!_ringbuffer_handle)
     {
         log_e("Could not create ringbuffer handle");

--- a/src/ESP32_VS1053_Stream.cpp
+++ b/src/ESP32_VS1053_Stream.cpp
@@ -11,7 +11,7 @@ ESP32_VS1053_Stream::~ESP32_VS1053_Stream()
 
 void ESP32_VS1053_Stream::_allocateRingbuffer()
 {
-    if (!psramFound())
+    if (!psramFound() || !VS1053_PSRAM_BUFFER)
         return;
 
     if (_buffer_struct)
@@ -166,7 +166,7 @@ bool ESP32_VS1053_Stream::startDecoder(const uint8_t CS, const uint8_t DCS, cons
     if (_vs1053->getChipVersion() == 4)
         _vs1053->loadDefaultVs1053Patches();
     setVolume(_volume);
-    if (psramFound())
+    if (!psramFound() || !VS1053_PSRAM_BUFFER)
         log_i("PSRAM found - %ikB buffer size set", VS1053_PSRAM_BUFFER_SIZE / 1024);
     return true;
 }

--- a/src/ESP32_VS1053_Stream.cpp
+++ b/src/ESP32_VS1053_Stream.cpp
@@ -399,9 +399,9 @@ void ESP32_VS1053_Stream::_playFromRingBuffer()
     {
         size_t size = 0;
 
-        taskENTER_CRITICAL(&rb_spinlock);
+        portDISABLE_INTERRUPTS();
         uint8_t *data = (uint8_t *)xRingbufferReceiveUpTo(_ringbuffer_handle, &size, pdMS_TO_TICKS(0), VS1053_BUFFERSIZE);
-        taskEXIT_CRITICAL(&rb_spinlock);
+        portENABLE_INTERRUPTS();
 
         if (!data)
         {
@@ -431,9 +431,9 @@ void ESP32_VS1053_Stream::_streamToRingBuffer(WiFiClient *const stream)
         const int BYTES_IN_BUFFER = stream->readBytes(_localbuffer, BYTES_TO_READ);
         log_d("%i bytes in buffer", BYTES_IN_BUFFER);
 
-        taskENTER_CRITICAL(&rb_spinlock);
+        portDISABLE_INTERRUPTS();
         const BaseType_t result = xRingbufferSend(_ringbuffer_handle, _localbuffer, BYTES_IN_BUFFER, pdMS_TO_TICKS(0));
-        taskEXIT_CRITICAL(&rb_spinlock);
+        portENABLE_INTERRUPTS();
 
         if (result == pdFALSE)
         {
@@ -512,9 +512,9 @@ void ESP32_VS1053_Stream::_chunkedStreamToRingBuffer(WiFiClient *const stream)
         const int BYTES_IN_BUFFER = stream->readBytes(_localbuffer, BYTES_TO_READ);
         log_d("%i bytes in buffer", BYTES_IN_BUFFER);
 
-        taskENTER_CRITICAL(&rb_spinlock);
+        portDISABLE_INTERRUPTS();
         const BaseType_t result = xRingbufferSend(_ringbuffer_handle, _localbuffer, BYTES_IN_BUFFER, pdMS_TO_TICKS(0));
-        taskEXIT_CRITICAL(&rb_spinlock);
+        portENABLE_INTERRUPTS();
 
         if (result == pdFALSE)
         {

--- a/src/ESP32_VS1053_Stream.cpp
+++ b/src/ESP32_VS1053_Stream.cpp
@@ -256,7 +256,7 @@ bool ESP32_VS1053_Stream::connecttohost(const char *url, const char *username,
             WiFiClient *stream = _http->getStreamPtr();
             if (!stream)
             {
-                log_e("No stream _ringbuffer_handle");
+                log_e("No stream handle");
                 stopSong();
                 return false;
             }

--- a/src/ESP32_VS1053_Stream.cpp
+++ b/src/ESP32_VS1053_Stream.cpp
@@ -429,7 +429,6 @@ void ESP32_VS1053_Stream::_streamToRingBuffer(WiFiClient *const stream)
             break;
 
         const int BYTES_IN_BUFFER = stream->readBytes(_localbuffer, BYTES_TO_READ);
-        log_d("%i bytes in buffer", BYTES_IN_BUFFER);
 
         portDISABLE_INTERRUPTS();
         const BaseType_t result = xRingbufferSend(_ringbuffer_handle, _localbuffer, BYTES_IN_BUFFER, pdMS_TO_TICKS(0));
@@ -441,11 +440,9 @@ void ESP32_VS1053_Stream::_streamToRingBuffer(WiFiClient *const stream)
             _remainingBytes = 0;
             return;
         }
-        else
-        {
-            bytesToRingBuffer += BYTES_IN_BUFFER;
-            _musicDataPosition += _metaDataStart ? BYTES_IN_BUFFER : 0;
-        }
+
+        bytesToRingBuffer += BYTES_IN_BUFFER;
+        _musicDataPosition += _metaDataStart ? BYTES_IN_BUFFER : 0;
     }
     log_d("%i bytes to ringbuffer", bytesToRingBuffer);
 }

--- a/src/ESP32_VS1053_Stream.cpp
+++ b/src/ESP32_VS1053_Stream.cpp
@@ -395,7 +395,7 @@ bool ESP32_VS1053_Stream::connecttohost(const char *url, const char *username,
 void ESP32_VS1053_Stream::_playFromRingBuffer()
 {
     size_t bytesToDecoder = 0;
-    while (_vs1053->data_request() && bytesToDecoder < VS1053_MAX_BYTES_PER_LOOP)
+    while (_remainingBytes && _vs1053->data_request() && bytesToDecoder < VS1053_MAX_BYTES_PER_LOOP)
     {
         size_t size = 0;
 
@@ -507,7 +507,6 @@ void ESP32_VS1053_Stream::_chunkedStreamToRingBuffer(WiFiClient *const stream)
             break;
 
         const int BYTES_IN_BUFFER = stream->readBytes(_localbuffer, BYTES_TO_READ);
-        log_d("%i bytes in buffer", BYTES_IN_BUFFER);
 
         portDISABLE_INTERRUPTS();
         const BaseType_t result = xRingbufferSend(_ringbuffer_handle, _localbuffer, BYTES_IN_BUFFER, pdMS_TO_TICKS(0));

--- a/src/ESP32_VS1053_Stream.cpp
+++ b/src/ESP32_VS1053_Stream.cpp
@@ -58,7 +58,7 @@ void ESP32_VS1053_Stream::_allocateRingbuffer()
         return;
     }
     else
-        log_d("Allocated %i bytes ringbuffer in PSRAM", VS1053_PSRAM_BUFFER_SIZE);
+        log_i("Allocated %i bytes ringbuffer in PSRAM", VS1053_PSRAM_BUFFER_SIZE);
 }
 
 void ESP32_VS1053_Stream::_deallocateRingbuffer()
@@ -166,8 +166,6 @@ bool ESP32_VS1053_Stream::startDecoder(const uint8_t CS, const uint8_t DCS, cons
     if (_vs1053->getChipVersion() == 4)
         _vs1053->loadDefaultVs1053Patches();
     setVolume(_volume);
-    if (!psramFound() || !VS1053_PSRAM_BUFFER)
-        log_i("PSRAM found - %ikB buffer size set", VS1053_PSRAM_BUFFER_SIZE / 1024);
     return true;
 }
 

--- a/src/ESP32_VS1053_Stream.cpp
+++ b/src/ESP32_VS1053_Stream.cpp
@@ -1,14 +1,12 @@
 #include "ESP32_VS1053_Stream.h"
 #include <freertos/ringbuf.h>
 
-ESP32_VS1053_Stream::ESP32_VS1053_Stream() : _vs1053(nullptr), _http(nullptr), _vs1053Buffer{0}, _localbuffer{0}, _ringbuffer_handle(nullptr), _buffer_struct(nullptr),
-                                             _buffer_storage(nullptr)
-{}
+ESP32_VS1053_Stream::ESP32_VS1053_Stream() : _vs1053(nullptr), _http(nullptr), _vs1053Buffer{0}, _localbuffer{0}, _url{0},
+                                             _ringbuffer_handle(nullptr), _buffer_struct(nullptr), _buffer_storage(nullptr) {}
 
 ESP32_VS1053_Stream::~ESP32_VS1053_Stream()
 {
     stopSong();
-    //_deallocateRingbuffer(); // Done by stopSong?
     delete _vs1053;
 }
 
@@ -17,7 +15,7 @@ void ESP32_VS1053_Stream::_allocateRingbuffer()
     // Allocate ring buffer structure, storage and handle in external RAM
     if (!psramFound())
         return;
-    
+
     if (_buffer_struct)
     {
         log_e("_buffer_struct not empty");
@@ -49,7 +47,7 @@ void ESP32_VS1053_Stream::_allocateRingbuffer()
     {
         log_e("_ringbuffer_handle in use");
         return;
-    }    
+    }
     _ringbuffer_handle = xRingbufferCreateStatic(VS1053_PSRAM_BUFFER_SIZE, VS1053_BUFFER_TYPE, _buffer_storage, _buffer_struct);
     if (!_ringbuffer_handle)
     {
@@ -170,6 +168,8 @@ bool ESP32_VS1053_Stream::startDecoder(const uint8_t CS, const uint8_t DCS, cons
     if (_vs1053->getChipVersion() == 4)
         _vs1053->loadDefaultVs1053Patches();
     setVolume(_volume);
+    if (psramFound())
+        log_i("%ikB PSRAM buffer will be used", VS1053_PSRAM_BUFFER_SIZE / 1024);
     return true;
 }
 

--- a/src/ESP32_VS1053_Stream.cpp
+++ b/src/ESP32_VS1053_Stream.cpp
@@ -522,12 +522,10 @@ void ESP32_VS1053_Stream::_chunkedStreamToRingBuffer(WiFiClient *const stream)
             _remainingBytes = 0;
             return;
         }
-        else
-        {
-            _bytesLeftInChunk -= BYTES_IN_BUFFER;
-            bytesToRingBuffer += BYTES_IN_BUFFER;
-            _musicDataPosition += _metaDataStart ? BYTES_IN_BUFFER : 0;
-        }
+
+        _bytesLeftInChunk -= BYTES_IN_BUFFER;
+        bytesToRingBuffer += BYTES_IN_BUFFER;
+        _musicDataPosition += _metaDataStart ? BYTES_IN_BUFFER : 0;
     }
     log_d("%i bytes from chunked stream to decoder", bytesToRingBuffer);
 }

--- a/src/ESP32_VS1053_Stream.cpp
+++ b/src/ESP32_VS1053_Stream.cpp
@@ -312,8 +312,6 @@ bool ESP32_VS1053_Stream::connecttohost(const char *url, const char *username,
 
         _remainingBytes = _http->getSize(); // -1 when Server sends no Content-Length header (chunked streams)
         _chunkedResponse = _http->header(ENCODING).equals("chunked") ? true : false;
-        if (_chunkedResponse)
-            log_i("Stream is chunked");
         _offset = (_remainingBytes == -1) ? 0 : offset;
         _metaDataStart = _http->header(ICY_METAINT).toInt();
         _musicDataPosition = _metaDataStart ? 0 : -100;
@@ -364,7 +362,7 @@ void ESP32_VS1053_Stream::_playFromRingBuffer()
         uint8_t *data = (uint8_t *)xRingbufferReceiveUpTo(_ringbuffer_handle, &size, pdMS_TO_TICKS(0), VS1053_BUFFERSIZE);
         if (!data)
         {
-            log_w("No ringbuffer data available");
+            log_d("No ringbuffer data available");
             break;
         }
         _vs1053->playChunk(data, size);
@@ -618,7 +616,7 @@ void ESP32_VS1053_Stream::loop()
 
     if (_noStreamStartTime)
     {
-        log_i("Stream blackout lasted %lu ms", millis() - _noStreamStartTime);
+        log_d("Stream blackout lasted %lu ms", millis() - _noStreamStartTime);
         _noStreamStartTime = 0;
     }
 
@@ -630,7 +628,7 @@ void ESP32_VS1053_Stream::loop()
         if (millis() - _startMute > WAIT_TIME_MS)
         {
             _vs1053->setVolume(_volume);
-            log_i("startmute is %lu milliseconds", WAIT_TIME_MS);
+            log_d("startmute is %lu milliseconds", WAIT_TIME_MS);
             _startMute = 0;
         }
     }

--- a/src/ESP32_VS1053_Stream.cpp
+++ b/src/ESP32_VS1053_Stream.cpp
@@ -1,5 +1,4 @@
 #include "ESP32_VS1053_Stream.h"
-#include <freertos/ringbuf.h>
 
 ESP32_VS1053_Stream::ESP32_VS1053_Stream() : _vs1053(nullptr), _http(nullptr), _vs1053Buffer{0}, _localbuffer{0}, _url{0},
                                              _ringbuffer_handle(nullptr), _buffer_struct(nullptr), _buffer_storage(nullptr) {}
@@ -39,7 +38,7 @@ void ESP32_VS1053_Stream::_allocateRingbuffer()
         log_e("Could not allocate ringbuffer storage");
 
         free(_buffer_struct);
-        _buffer_struct = NULL;
+        _buffer_struct = nullptr;
         return;
     }
 
@@ -54,9 +53,9 @@ void ESP32_VS1053_Stream::_allocateRingbuffer()
         log_e("Could not create ringbuffer handle");
 
         free(_buffer_storage);
-        _buffer_storage = NULL;
+        _buffer_storage = nullptr;
         free(_buffer_struct);
-        _buffer_struct = NULL;
+        _buffer_struct = nullptr;
         return;
     }
     else
@@ -68,17 +67,17 @@ void ESP32_VS1053_Stream::_deallocateRingbuffer()
     if (_ringbuffer_handle)
     {
         vRingbufferDelete(_ringbuffer_handle);
-        _ringbuffer_handle = NULL;
+        _ringbuffer_handle = nullptr;
     }
     if (_buffer_storage)
     {
         free(_buffer_storage);
-        _buffer_storage = NULL;
+        _buffer_storage = nullptr;
     }
     if (_buffer_struct)
     {
         free(_buffer_struct);
-        _buffer_struct = NULL;
+        _buffer_struct = nullptr;
     }
 }
 
@@ -169,7 +168,7 @@ bool ESP32_VS1053_Stream::startDecoder(const uint8_t CS, const uint8_t DCS, cons
         _vs1053->loadDefaultVs1053Patches();
     setVolume(_volume);
     if (psramFound())
-        log_i("%ikB PSRAM buffer will be used", VS1053_PSRAM_BUFFER_SIZE / 1024);
+        log_i("PSRAM found - %ikB buffer size set", VS1053_PSRAM_BUFFER_SIZE / 1024);
     return true;
 }
 
@@ -420,7 +419,6 @@ void ESP32_VS1053_Stream::_playFromRingBuffer()
 
 void ESP32_VS1053_Stream::_streamToRingBuffer(WiFiClient *const stream)
 {
-    // read available non chunked http data into ringbuffer until metadata start
     size_t bytesToRingBuffer = 0;
     while (stream->available() && _musicDataPosition < _metaDataStart &&
            bytesToRingBuffer < VS1053_MAX_BYTES_PER_LOOP)
@@ -471,7 +469,6 @@ void ESP32_VS1053_Stream::_handleStream(WiFiClient *const stream)
     }
     else
     {
-        // play straight from http stream buffer until _metaDataStart
         size_t bytesToDecoder = 0;
         while (stream->available() && _vs1053->data_request() && _remainingBytes &&
                _musicDataPosition < _metaDataStart && bytesToDecoder < VS1053_MAX_BYTES_PER_LOOP)
@@ -487,7 +484,6 @@ void ESP32_VS1053_Stream::_handleStream(WiFiClient *const stream)
         log_d("%i bytes from stream to decoder", bytesToDecoder);
     }
 
-    // read the metadata and call 'audio_showstreamtitle()' if it is defined
     if (_metaDataStart && _musicDataPosition == _metaDataStart && stream->available())
     {
         const auto METALENGTH = stream->read() * 16;
@@ -504,7 +500,6 @@ void ESP32_VS1053_Stream::_handleStream(WiFiClient *const stream)
 
 void ESP32_VS1053_Stream::_chunkedStreamToRingBuffer(WiFiClient *const stream)
 {
-    // read available http data into ringbuffer until metadata start OR until end of chunk
     size_t bytesToRingBuffer = 0;
     while (_bytesLeftInChunk && _musicDataPosition < _metaDataStart &&
            bytesToRingBuffer < VS1053_MAX_BYTES_PER_LOOP)
@@ -565,7 +560,6 @@ void ESP32_VS1053_Stream::_handleChunkedStream(WiFiClient *const stream)
     }
     else
     {
-        // play straight from the http client buffer
         size_t bytesToDecoder = 0;
         while (_bytesLeftInChunk && _vs1053->data_request() && _musicDataPosition < _metaDataStart && bytesToDecoder < VS1053_MAX_BYTES_PER_LOOP)
         {
@@ -630,8 +624,6 @@ void ESP32_VS1053_Stream::_handleChunkedStream(WiFiClient *const stream)
 
 void ESP32_VS1053_Stream::loop()
 {
-    // log_i("%i",  _remainingBytes);
-
     if (!_http && !_remainingBytes)
         return;
 
@@ -699,7 +691,7 @@ void ESP32_VS1053_Stream::loop()
 
 bool ESP32_VS1053_Stream::isRunning()
 {
-    return _http != NULL;
+    return _http != nullptr;
 }
 
 void ESP32_VS1053_Stream::stopSong()
@@ -715,7 +707,7 @@ void ESP32_VS1053_Stream::stopSong()
     }
     _http->end();
     delete _http;
-    _http = NULL;
+    _http = nullptr;
     _vs1053->stopSong();
     _deallocateRingbuffer();
     _dataSeen = false;

--- a/src/ESP32_VS1053_Stream.cpp
+++ b/src/ESP32_VS1053_Stream.cpp
@@ -58,7 +58,7 @@ void ESP32_VS1053_Stream::_allocateRingbuffer()
         return;
     }
     else
-        log_i("Allocated %i bytes ringbuffer in PSRAM", VS1053_PSRAM_BUFFER_SIZE);
+        log_d("Allocated %i bytes ringbuffer in PSRAM", VS1053_PSRAM_BUFFER_SIZE);
 }
 
 void ESP32_VS1053_Stream::_deallocateRingbuffer()
@@ -434,7 +434,7 @@ void ESP32_VS1053_Stream::_streamToRingBuffer(WiFiClient *const stream)
 
         if (result == pdFALSE)
         {
-            log_e("ringbuffer is unexpected full? Aborting...");
+            log_e("ringbuffer failed to receive %i bytes. Closing stream.");
             _remainingBytes = 0;
             return;
         }
@@ -512,7 +512,7 @@ void ESP32_VS1053_Stream::_chunkedStreamToRingBuffer(WiFiClient *const stream)
 
         if (result == pdFALSE)
         {
-            log_e("ringbuffer is unexpected full? Aborting...");
+            log_e("ringbuffer failed to receive %i bytes. Closing stream.");
             _remainingBytes = 0;
             return;
         }
@@ -609,7 +609,7 @@ void ESP32_VS1053_Stream::_handleChunkedStream(WiFiClient *const stream)
 
 void ESP32_VS1053_Stream::loop()
 {
-    if (!_http && !_remainingBytes)
+    if (!_http)
         return;
 
     if (!_http->connected())

--- a/src/ESP32_VS1053_Stream.cpp
+++ b/src/ESP32_VS1053_Stream.cpp
@@ -562,7 +562,8 @@ void ESP32_VS1053_Stream::_handleChunkedStream(WiFiClient *const stream)
         _musicDataPosition = 0;
     }
 
-    if (!_remainingBytes ) {
+    if (!_remainingBytes)
+    {
         _eofStream();
         return;
     }
@@ -576,7 +577,7 @@ void ESP32_VS1053_Stream::_handleChunkedStream(WiFiClient *const stream)
 
 void ESP32_VS1053_Stream::loop()
 {
-    //log_i("%i",  _remainingBytes);
+    // log_i("%i",  _remainingBytes);
 
     if (!_http && !_remainingBytes)
         return;
@@ -596,7 +597,6 @@ void ESP32_VS1053_Stream::loop()
         return;
     }
 
-
     if (!stream->available())
     {
         if (!_noStreamStartTime)
@@ -611,7 +611,6 @@ void ESP32_VS1053_Stream::loop()
             _eofStream();
             return;
         }
-        
     }
 
     if (_noStreamStartTime)
@@ -653,6 +652,13 @@ bool ESP32_VS1053_Stream::isRunning()
 void ESP32_VS1053_Stream::stopSong()
 {
     // if there is a psram ringbuffer, reset it (except when paused)
+    size_t item_size;
+    char *item = (char *)xRingbufferReceiveUpTo(_ringbuffer_handle, &item_size, pdMS_TO_TICKS(1000), VS1053_PSRAM_BUFFER_SIZE - xRingbufferGetCurFreeSize(_ringbuffer_handle));
+    // Check received data
+    if (item != NULL)
+    {
+        vRingbufferReturnItem(_ringbuffer_handle, (void *)item);
+    }
 
     if (!_http)
         return;

--- a/src/ESP32_VS1053_Stream.h
+++ b/src/ESP32_VS1053_Stream.h
@@ -100,6 +100,7 @@ private:
     bool _dataSeen = false;
     unsigned long _noStreamStartTime = 0;
     uint8_t _redirectCount = 0;
+    portMUX_TYPE rb_spinlock = portMUX_INITIALIZER_UNLOCKED;
 
     enum codec_t
     {

--- a/src/ESP32_VS1053_Stream.h
+++ b/src/ESP32_VS1053_Stream.h
@@ -3,6 +3,9 @@
 
 #include <Arduino.h>
 #include <HTTPClient.h>
+#include <freertos/ringbuf.h>
+#include <freertos/semphr.h>
+#include <esp_heap_caps.h>
 #include <VS1053.h> /* https://github.com/baldram/ESP_VS1053_Library */
 
 #define VS1053_INITIALVOLUME 95
@@ -17,6 +20,9 @@
 
 #define VS1053_MAXVOLUME 100         /* do not change */
 #define VS1053_BUFFERSIZE size_t(32) /* do not change */
+
+#define VS1053_PSRAM_BUFFER_SIZE 400000 // 32-bit aligned size
+#define VS1053_BUFFER_TYPE RINGBUF_TYPE_NOSPLIT
 
 extern void audio_showstation(const char *) __attribute__((weak));
 extern void audio_eof_stream(const char *) __attribute__((weak));
@@ -60,6 +66,10 @@ private:
     VS1053 *_vs1053;
     HTTPClient *_http;
     uint8_t _vs1053Buffer[VS1053_BUFFERSIZE];
+
+    RingbufHandle_t _ringbuffer_handle;
+    StaticRingbuffer_t *_buffer_struct;
+    uint8_t *_buffer_storage;
 
     size_t _nextChunkSize(WiFiClient *const stream);
     bool _checkSync(WiFiClient *const stream);

--- a/src/ESP32_VS1053_Stream.h
+++ b/src/ESP32_VS1053_Stream.h
@@ -84,6 +84,8 @@ private:
     void _playFromRingBuffer();
     void _streamToRingBuffer(WiFiClient *const stream);
     void _chunkedStreamToRingBuffer(WiFiClient *const stream);
+    void _allocateRingbuffer();
+    void _deallocateRingbuffer();
 
     char _url[VS1053_MAX_URL_LENGTH];
     unsigned long _startMute = 0;

--- a/src/ESP32_VS1053_Stream.h
+++ b/src/ESP32_VS1053_Stream.h
@@ -99,7 +99,6 @@ private:
     bool _dataSeen = false;
     unsigned long _streamStalledTime = 0;
     uint8_t _redirectCount = 0;
-    portMUX_TYPE rb_spinlock = portMUX_INITIALIZER_UNLOCKED;
 
     enum codec_t
     {

--- a/src/ESP32_VS1053_Stream.h
+++ b/src/ESP32_VS1053_Stream.h
@@ -91,7 +91,6 @@ private:
     int _bitrate = 0;
     bool _chunkedResponse = false;
     bool _dataSeen = false;
-    unsigned long _emptyBufferStartTime = 0;
     uint8_t _redirectCount = 0;
 
     enum codec_t

--- a/src/ESP32_VS1053_Stream.h
+++ b/src/ESP32_VS1053_Stream.h
@@ -79,6 +79,8 @@ private:
     bool _canRedirect();
     void _handleStream(WiFiClient *const stream);
     void _handleChunkedStream(WiFiClient *const stream);
+    void _playFromRingBuffer();
+    void _streamToRingBuffer(WiFiClient *const stream);
 
     char _url[VS1053_MAX_URL_LENGTH];
     unsigned long _startMute = 0;

--- a/src/ESP32_VS1053_Stream.h
+++ b/src/ESP32_VS1053_Stream.h
@@ -20,7 +20,7 @@
 #define VS1053_MAXVOLUME 100         /* do not change */
 #define VS1053_BUFFERSIZE size_t(32) /* do not change */
 
-#define VS1053_PSRAM_BUFFER false
+#define VS1053_PSRAM_BUFFER true
 #define VS1053_PSRAM_BUFFER_SIZE 1024 * 32 // 32-bit aligned size
 #define VS1053_PSRAM_MAX_MOVE size_t(1024 * 8)
 #define VS1053_BUFFER_TYPE RINGBUF_TYPE_BYTEBUF

--- a/src/ESP32_VS1053_Stream.h
+++ b/src/ESP32_VS1053_Stream.h
@@ -15,14 +15,14 @@
 #define VS1053_DATA_TIMEOUT_MS 900
 #define VS1053_MAX_PLAYLIST_READ 1024
 #define VS1053_MAX_URL_LENGTH 512
-#define VS1053_MAX_BYTES_PER_LOOP 16384
+#define VS1053_MAX_BYTES_PER_LOOP 8192
 #define VS1053_MAX_REDIRECT_COUNT 3
 
 #define VS1053_MAXVOLUME 100         /* do not change */
 #define VS1053_BUFFERSIZE size_t(32) /* do not change */
 
-#define VS1053_PSRAM_BUFFER_SIZE 400000 // 32-bit aligned size
-#define VS1053_BUFFER_TYPE RINGBUF_TYPE_NOSPLIT
+#define VS1053_PSRAM_BUFFER_SIZE 262144 // 32-bit aligned size
+#define VS1053_BUFFER_TYPE RINGBUF_TYPE_BYTEBUF
 
 extern void audio_showstation(const char *) __attribute__((weak));
 extern void audio_eof_stream(const char *) __attribute__((weak));
@@ -91,6 +91,7 @@ private:
     int _bitrate = 0;
     bool _chunkedResponse = false;
     bool _dataSeen = false;
+    unsigned long _noStreamStartTime = 0;
     uint8_t _redirectCount = 0;
 
     enum codec_t

--- a/src/ESP32_VS1053_Stream.h
+++ b/src/ESP32_VS1053_Stream.h
@@ -15,13 +15,14 @@
 #define VS1053_DATA_TIMEOUT_MS 900
 #define VS1053_MAX_PLAYLIST_READ 1024
 #define VS1053_MAX_URL_LENGTH 512
-#define VS1053_MAX_BYTES_PER_LOOP 8192
+#define VS1053_MAX_BYTES_PER_LOOP (size_t)8192
 #define VS1053_MAX_REDIRECT_COUNT 3
 
 #define VS1053_MAXVOLUME 100         /* do not change */
 #define VS1053_BUFFERSIZE size_t(32) /* do not change */
 
-#define VS1053_PSRAM_BUFFER_SIZE 262144 // 32-bit aligned size
+#define VS1053_PSRAM_BUFFER_SIZE 1024 * 32 // 32-bit aligned size
+#define VS1053_PSRAM_MAX_MOVE size_t(1024 * 5)
 #define VS1053_BUFFER_TYPE RINGBUF_TYPE_BYTEBUF
 
 extern void audio_showstation(const char *) __attribute__((weak));
@@ -81,6 +82,7 @@ private:
     void _handleChunkedStream(WiFiClient *const stream);
     void _playFromRingBuffer();
     void _streamToRingBuffer(WiFiClient *const stream);
+    void _chunkedStreamToRingBuffer(WiFiClient *const stream);
 
     char _url[VS1053_MAX_URL_LENGTH];
     unsigned long _startMute = 0;

--- a/src/ESP32_VS1053_Stream.h
+++ b/src/ESP32_VS1053_Stream.h
@@ -15,14 +15,14 @@
 #define VS1053_DATA_TIMEOUT_MS 900
 #define VS1053_MAX_PLAYLIST_READ 1024
 #define VS1053_MAX_URL_LENGTH 512
-#define VS1053_MAX_BYTES_PER_LOOP (size_t)8192 * 2
+#define VS1053_MAX_BYTES_PER_LOOP size_t(1024 * 16)
 #define VS1053_MAX_REDIRECT_COUNT 3
 
 #define VS1053_MAXVOLUME 100         /* do not change */
 #define VS1053_BUFFERSIZE size_t(32) /* do not change */
 
 #define VS1053_PSRAM_BUFFER_SIZE 1024 * 32 // 32-bit aligned size
-#define VS1053_PSRAM_MAX_MOVE size_t(1024 * 10)
+#define VS1053_PSRAM_MAX_MOVE size_t(1024 * 8)
 #define VS1053_BUFFER_TYPE RINGBUF_TYPE_BYTEBUF
 
 extern void audio_showstation(const char *) __attribute__((weak));
@@ -68,6 +68,7 @@ private:
     HTTPClient *_http;
     uint8_t _vs1053Buffer[VS1053_BUFFERSIZE];
     uint8_t _localbuffer[VS1053_PSRAM_MAX_MOVE];
+    char _url[VS1053_MAX_URL_LENGTH];
 
     RingbufHandle_t _ringbuffer_handle;
     StaticRingbuffer_t *_buffer_struct;
@@ -81,13 +82,12 @@ private:
     bool _canRedirect();
     void _handleStream(WiFiClient *const stream);
     void _handleChunkedStream(WiFiClient *const stream);
+    void _allocateRingbuffer();
+    void _deallocateRingbuffer();
     void _playFromRingBuffer();
     void _streamToRingBuffer(WiFiClient *const stream);
     void _chunkedStreamToRingBuffer(WiFiClient *const stream);
-    void _allocateRingbuffer();
-    void _deallocateRingbuffer();
 
-    char _url[VS1053_MAX_URL_LENGTH];
     unsigned long _startMute = 0;
     size_t _offset = 0;
     size_t _remainingBytes = 0;

--- a/src/ESP32_VS1053_Stream.h
+++ b/src/ESP32_VS1053_Stream.h
@@ -97,7 +97,7 @@ private:
     int _bitrate = 0;
     bool _chunkedResponse = false;
     bool _dataSeen = false;
-    unsigned long _noStreamStartTime = 0;
+    unsigned long _streamStalledTime = 0;
     uint8_t _redirectCount = 0;
     portMUX_TYPE rb_spinlock = portMUX_INITIALIZER_UNLOCKED;
 

--- a/src/ESP32_VS1053_Stream.h
+++ b/src/ESP32_VS1053_Stream.h
@@ -15,14 +15,14 @@
 #define VS1053_DATA_TIMEOUT_MS 900
 #define VS1053_MAX_PLAYLIST_READ 1024
 #define VS1053_MAX_URL_LENGTH 512
-#define VS1053_MAX_BYTES_PER_LOOP (size_t)8192
+#define VS1053_MAX_BYTES_PER_LOOP (size_t)8192 * 2
 #define VS1053_MAX_REDIRECT_COUNT 3
 
 #define VS1053_MAXVOLUME 100         /* do not change */
 #define VS1053_BUFFERSIZE size_t(32) /* do not change */
 
 #define VS1053_PSRAM_BUFFER_SIZE 1024 * 32 // 32-bit aligned size
-#define VS1053_PSRAM_MAX_MOVE size_t(1024 * 5)
+#define VS1053_PSRAM_MAX_MOVE size_t(1024 * 10)
 #define VS1053_BUFFER_TYPE RINGBUF_TYPE_BYTEBUF
 
 extern void audio_showstation(const char *) __attribute__((weak));
@@ -67,6 +67,7 @@ private:
     VS1053 *_vs1053;
     HTTPClient *_http;
     uint8_t _vs1053Buffer[VS1053_BUFFERSIZE];
+    uint8_t _localbuffer[VS1053_PSRAM_MAX_MOVE];
 
     RingbufHandle_t _ringbuffer_handle;
     StaticRingbuffer_t *_buffer_struct;

--- a/src/ESP32_VS1053_Stream.h
+++ b/src/ESP32_VS1053_Stream.h
@@ -23,7 +23,6 @@
 #define VS1053_PSRAM_BUFFER true
 #define VS1053_PSRAM_BUFFER_SIZE 1024 * 32 // 32-bit aligned size
 #define VS1053_PSRAM_MAX_MOVE size_t(1024 * 8)
-#define VS1053_BUFFER_TYPE RINGBUF_TYPE_BYTEBUF
 
 extern void audio_showstation(const char *) __attribute__((weak));
 extern void audio_eof_stream(const char *) __attribute__((weak));

--- a/src/ESP32_VS1053_Stream.h
+++ b/src/ESP32_VS1053_Stream.h
@@ -20,6 +20,7 @@
 #define VS1053_MAXVOLUME 100         /* do not change */
 #define VS1053_BUFFERSIZE size_t(32) /* do not change */
 
+#define VS1053_PSRAM_BUFFER false
 #define VS1053_PSRAM_BUFFER_SIZE 1024 * 32 // 32-bit aligned size
 #define VS1053_PSRAM_MAX_MOVE size_t(1024 * 8)
 #define VS1053_BUFFER_TYPE RINGBUF_TYPE_BYTEBUF

--- a/src/ESP32_VS1053_Stream.h
+++ b/src/ESP32_VS1053_Stream.h
@@ -4,7 +4,6 @@
 #include <Arduino.h>
 #include <HTTPClient.h>
 #include <freertos/ringbuf.h>
-#include <freertos/semphr.h>
 #include <esp_heap_caps.h>
 #include <VS1053.h> /* https://github.com/baldram/ESP_VS1053_Library */
 

--- a/src/ESP32_VS1053_Stream.h
+++ b/src/ESP32_VS1053_Stream.h
@@ -90,7 +90,7 @@ private:
 
     unsigned long _startMute = 0;
     size_t _offset = 0;
-    size_t _remainingBytes = 0;
+    int32_t _remainingBytes = 0;
     size_t _bytesLeftInChunk = 0;
     int32_t _metaDataStart = 0;
     int32_t _musicDataPosition = 0;


### PR DESCRIPTION
This PR adds a 32kB playback ringbuffer on boards with psram.

To override this behaviour -and have no ringbuffer- set 'VS1053_PSRAM_BUFFER' to 'false'.

On boards without psram the streams will be played straight from the HTTPClient buffer as before. 