### PR TITLE
Change function names to camelCase

### DIFF
--- a/src/ESP32_VS1053_Stream.cpp
+++ b/src/ESP32_VS1053_Stream.cpp
@@ -158,23 +158,23 @@ bool ESP32_VS1053_Stream::isChipConnected()
     return _vs1053 ? _vs1053->isChipConnected() : false;
 }
 
-bool ESP32_VS1053_Stream::connecttohost(const char *url)
+bool ESP32_VS1053_Stream::connectToHost(const char *url)
 {
-    return connecttohost(url, "", "", 0);
+    return connectToHost(url, "", "", 0);
 }
 
-bool ESP32_VS1053_Stream::connecttohost(const char *url, const size_t offset)
+bool ESP32_VS1053_Stream::connectToHost(const char *url, const size_t offset)
 {
-    return connecttohost(url, "", "", offset);
+    return connectToHost(url, "", "", offset);
 }
 
-bool ESP32_VS1053_Stream::connecttohost(const char *url, const char *username,
+bool ESP32_VS1053_Stream::connectToHost(const char *url, const char *username,
                                         const char *pwd)
 {
-    return connecttohost(url, username, pwd, 0);
+    return connectToHost(url, username, pwd, 0);
 }
 
-bool ESP32_VS1053_Stream::connecttohost(const char *url, const char *username,
+bool ESP32_VS1053_Stream::connectToHost(const char *url, const char *username,
                                         const char *pwd, size_t offset)
 {
     if (!_vs1053 || _http || _playingFile || !WiFi.isConnected() ||
@@ -303,7 +303,7 @@ bool ESP32_VS1053_Stream::connecttohost(const char *url, const char *username,
             strtok(newurl, "\r\n;?");
             stopSong();
             log_d("playlist reconnects to: %s", newurl);
-            return connecttohost(newurl, username, pwd, offset);
+            return connectToHost(newurl, username, pwd, offset);
         }
 
         else if (CONTENT.equals("audio/mpeg"))
@@ -809,12 +809,12 @@ void ESP32_VS1053_Stream::bufferStatus(size_t &used, size_t &capacity)
     capacity = _ringbuffer_handle ? VS1053_PSRAM_BUFFER_SIZE : 0;
 }
 
-bool ESP32_VS1053_Stream::connecttofile(fs::FS &fs, const char *filename)
+bool ESP32_VS1053_Stream::connectToFile(fs::FS &fs, const char *filename)
 {
-    return connecttofile(fs, filename, 0);
+    return connectToFile(fs, filename, 0);
 }
 
-bool ESP32_VS1053_Stream::connecttofile(fs::FS &fs, const char *filename, const size_t offset)
+bool ESP32_VS1053_Stream::connectToFile(fs::FS &fs, const char *filename, const size_t offset)
 {
     if (!_vs1053 || _playingFile || _http)
         return false;

--- a/src/ESP32_VS1053_Stream.h
+++ b/src/ESP32_VS1053_Stream.h
@@ -40,13 +40,13 @@ public:
     bool startDecoder(const uint8_t CS, const uint8_t DCS, const uint8_t DREQ);
     bool isChipConnected();
 
-    bool connecttohost(const char *url);
-    bool connecttohost(const char *url, const size_t offset);
-    bool connecttohost(const char *url, const char *username, const char *pwd);
-    bool connecttohost(const char *url, const char *username, const char *pwd, const size_t offset);
+    bool connectToHost(const char *url);
+    bool connectToHost(const char *url, const size_t offset);
+    bool connectToHost(const char *url, const char *username, const char *pwd);
+    bool connectToHost(const char *url, const char *username, const char *pwd, const size_t offset);
 
-    bool connecttofile(fs::FS &fs, const char *filename);
-    bool connecttofile(fs::FS &fs, const char *filename, const size_t offset);
+    bool connectToFile(fs::FS &fs, const char *filename);
+    bool connectToFile(fs::FS &fs, const char *filename, const size_t offset);
 
     void loop();
     bool isRunning();
@@ -68,6 +68,26 @@ public:
     uint32_t bitrate();
     const char *bufferStatus();
     void bufferStatus(size_t &used, size_t &capacity);
+
+
+    // Compatibility with old function names (deprecated)
+    [[deprecated("Use connectToHost instead")]]
+    inline bool connecttohost(const char *url) { return connectToHost(url); }
+
+    [[deprecated("Use connectToHost instead")]]
+    inline bool connecttohost(const char *url, const size_t offset) { return connectToHost(url, offset); }
+
+    [[deprecated("Use connectToHost instead")]]
+    inline bool connecttohost(const char *url, const char *username, const char *pwd) { return connectToHost(url, username, pwd); }
+
+    [[deprecated("Use connectToHost instead")]]
+    inline bool connecttohost(const char *url, const char *username, const char *pwd, const size_t offset) { return connectToHost(url, username, pwd, offset); }
+
+    [[deprecated("Use connectToFile instead")]]
+    inline bool connecttofile(fs::FS &fs, const char *filename) { return connectToFile(fs, filename); }
+
+    [[deprecated("Use connectToFile instead")]]
+    inline bool connecttofile(fs::FS &fs, const char *filename, const size_t offset) { return connectToFile(fs, filename, offset); }
 
 private:
     VS1053 *_vs1053;


### PR DESCRIPTION
To get more consistent the function names will be changed to camelCase.

The old names will be dropped in 3.0.0.